### PR TITLE
add bdist-rpm dependencies to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [metadata]
 description-file = README.rst
+[bdist_rpm]
+requires = python >= 2.7
+           django >= 1.8
+           django-jquery-js


### PR DESCRIPTION
This makes python setup.py bdist_rpm generate rpm's with the correct dependencies. Usually they are included from the install_requires in setup.py, but when a setup.cfg file is detected no new setup.cfg with the correct dependencies is generated by some build frameworks.