### PR TITLE
add confirmDeleteText option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,10 @@ The ``data-formset-`` data attributes are:
   The value of ``{{ formset.prefix }}``.
   This is used to find the management form.
 
+``data-formset-delete-confirm-text``
+  A question to ask the user to confirm a click on the delete button,
+  e.g. "Do you really want to delete this entry?". Optional.
+
 ``data-formset-body``
   This indicates where all the child forms are.
   New forms are inserted in here.

--- a/djangoformsetjs/static/js/jquery.formset.js
+++ b/djangoformsetjs/static/js/jquery.formset.js
@@ -21,6 +21,7 @@
         this.$add = this.$formset.find(this.opts.add);
 
         this.formsetPrefix = $(el).data('formset-prefix');
+        this.deleteConfirmText = $(el).data('formset-delete-confirm-text');
 
         // Bind to the `Add form` button
         this.addForm = $.proxy(this, 'addForm');
@@ -139,8 +140,11 @@
 
         // Delete the form if the delete button is pressed
         var $deleteButton = $form.find(this.opts.deleteButton);
+        var deleteConfirmText = this.deleteConfirmText;
         $deleteButton.bind('click', function() {
-            $delete.attr('checked', true).change();
+            if(!deleteConfirmText || confirm(deleteConfirmText)) {
+                $delete.attr('checked', true).change();
+            }
         });
 
         $order.change(function(event) {


### PR DESCRIPTION
The "delete" button currently deletes the form instantly, without confirmation or any way to get it back. This adds the `confirmDeleteText` option allowing devs to add a simple confirmation dialog, possibly saving users from deleting something they don't want to delete.